### PR TITLE
Fix dataset usage

### DIFF
--- a/utilities/crypto_detect.py
+++ b/utilities/crypto_detect.py
@@ -119,8 +119,8 @@ def load_definitions(definitions_dir: str) -> dict:
                 print_trace(f'Loading definition: {file}')
                 with open(os.path.join(root, file), 'r') as yaml_file:
                     data = yaml.safe_load(yaml_file)
-                    if 'section3' in data and 'keywords' in data['section3']:
-                        for keyword in data['section3']['keywords']:
+                    if 'keywords' in data:
+                        for keyword in data['keywords']:
                             definitions[keyword].append(file)
     return definitions
 


### PR DESCRIPTION
Currently crypto_detect.py is not loading any definitions:

```
python utilities/crypto_detect.py /tmp/test -c definitions_crypto_algorithms/list_definitions_crypto_algorithms 
Error: Failed to load definitions for: definitions_crypto_algorithms/list_definitions_crypto_algorithms
```

This is because there is no current `section3` element in the proposed dataset.