### PR TITLE
Remove duplicated algorithms folder

### DIFF
--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/blum-goldwasser.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/blum-goldwasser.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Blum-Goldwasser Probabilistic Public-key Encryption
-algorithmId: blum-goldwasser
-category: Asymmetric Encryption
-strength: "320"

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/dhe.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/dhe.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Diffie-Hellman Ephemeral
-algorithmId: dhe
-category: Asymmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/dhies.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/dhies.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Diffie-Hellman Integrated Encryption Scheme
-algorithmId: dhies
-category: Asymmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/dsa.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/dsa.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Digital Signature Algorithm
-algorithmId: dsa
-category: Asymmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/ecc.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/ecc.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Elliptic Curve Cryptography
-algorithmId: ecc
-category: Asymmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/ecdh.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/ecdh.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Elliptic Curve Diffie-Hellman
-algorithmId: ecdh
-category: Asymmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/ecdsa.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/ecdsa.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Elliptic Curve Digital Signature Algorithm
-algorithmId: ecdsa
-category: Asymmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/ecmqv.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/ecmqv.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Elliptic Curve Menezes-Qu-Vanstone
-algorithmId: ecmqv
-category: Asymmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/ed25519.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/ed25519.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Edwards-curve Digital Signature Algorithm
-algorithmId: ed25519
-category: Asymmetric Encryption
-strength: ""

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/elgamal.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/elgamal.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: ElGamal
-algorithmId: elgamal
-category: Asymmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/luc.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/luc.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: LUC Public Key Cryptosystem
-algorithmId: luc
-category: Asymmetric Encryption
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/mqv.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/mqv.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Menezes-Qu-Vanstone
-algorithmId: mqv
-category: Asymmetric Encryption
-strength: "512"

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/naccachestern.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/naccachestern.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Naccache-Stern Encryption Algorithm
-algorithmId: naccachestern
-category: Asymmetric Encryption
-strength: 1024-2048

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/rabin.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/rabin.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Rabin
-algorithmId: rabin
-category: Asymmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/rsa-oaep.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/rsa-oaep.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: RSA with Optimal Asymmetric Encryption Padding
-algorithmId: rsa-oaep
-category: Asymmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/rsa.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/rsa.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: RSA Cryptosystem
-algorithmId: rsa
-category: Asymmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/xtr.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Asymmetric Encryption/xtr.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: XTR Public Key System
-algorithmId: xtr
-category: Asymmetric Encryption
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Authentication/eccpwd.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Authentication/eccpwd.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Elliptic Curve Password Authenticated Key Exchange
-algorithmId: eccpwd
-category: Authentication
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Authentication/kerberos.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Authentication/kerberos.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Kerberos Authentication Protocol
-algorithmId: kerberos
-category: Authentication
-strength: 56-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Authentication/psk.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Authentication/psk.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Pre-Shared Key Authentication
-algorithmId: psk
-category: Authentication
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/cbc.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/cbc.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Cipher Block Chaining
-algorithmId: cbc
-category: Block Cipher Modes
-strength: ""

--- a/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/ccm.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/ccm.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Counter with CBC-MAC
-algorithmId: ccm
-category: Block Cipher Modes
-strength: ""

--- a/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/cfb.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/cfb.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Cipher Feedback
-algorithmId: cfb
-category: Block Cipher Modes
-strength: ""

--- a/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/ctr.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/ctr.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Counter Cipher
-algorithmId: ctr
-category: Block Cipher Modes
-strength: ""

--- a/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/ecb.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/ecb.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Electronic Codebook
-algorithmId: ecb
-category: Block Cipher Modes
-strength: ""

--- a/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/gcm.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/gcm.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Galois/Counter Mode
-algorithmId: gcm
-category: Block Cipher Modes
-strength: ""

--- a/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/ofb.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/ofb.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Output Feedback
-algorithmId: ofb
-category: Block Cipher Modes
-strength: ""

--- a/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/xts.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Block Cipher Modes/xts.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: XEX-Based Codebook mode
-algorithmId: xts
-category: Block Cipher Modes
-strength: ""

--- a/definitions_crypto_algorithms/definitions/algorithms/Certificate Formats/ASN1.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Certificate Formats/ASN1.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Abstract Syntax Notation One
-algorithmId: ASN1
-category: Certificate Formats
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Certificate Formats/pgp.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Certificate Formats/pgp.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Pretty Good Privacy
-algorithmId: pgp
-category: Certificate Formats
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Certificate Formats/pkcs12.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Certificate Formats/pkcs12.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: 'PKCS #12: Personal Information Exchange Syntax'
-algorithmId: pkcs12
-category: Certificate Formats
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Certificate Formats/pkcs7.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Certificate Formats/pkcs7.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: 'PKCS #7: Cryptographic Message Syntax'
-algorithmId: pkcs7
-category: Certificate Formats
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Cryptographic Primitive/xoodyak.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Cryptographic Primitive/xoodyak.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Xoodyak Cryptographic Primitive
-algorithmId: xoodyak
-category: Cryptographic Primitive
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Data Clustering/dcc.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Data Clustering/dcc.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Dynamic Contrastive Clustering
-algorithmId: dcc
-category: Data Clustering
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Digital Signature Algorithm/dss.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Digital Signature Algorithm/dss.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Digital Signature Standard
-algorithmId: dss
-category: Digital Signature Algorithm
-strength: 1024-3072

--- a/definitions_crypto_algorithms/definitions/algorithms/Digital Signature Algorithm/dstu4145.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Digital Signature Algorithm/dstu4145.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: DSTU 4145 Digital Signature Algorithm
-algorithmId: dstu4145
-category: Digital Signature Algorithm
-strength: 163-431

--- a/definitions_crypto_algorithms/definitions/algorithms/Digital Signature Algorithm/ecnr.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Digital Signature Algorithm/ecnr.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Elliptic Curve Nyberg-Rueppel Signature Algorithm
-algorithmId: ecnr
-category: Digital Signature Algorithm
-strength: 160-521

--- a/definitions_crypto_algorithms/definitions/algorithms/Digital Signature Algorithm/ed448.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Digital Signature Algorithm/ed448.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Edwards-Curve Digital Signature Algorithm 448
-algorithmId: ed448
-category: Digital Signature Algorithm
-strength: "224"

--- a/definitions_crypto_algorithms/definitions/algorithms/Digital Signature Algorithm/eddsa.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Digital Signature Algorithm/eddsa.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Edwards-Curve Digital Signature Algorithm
-algorithmId: eddsa
-category: Digital Signature Algorithm
-strength: 128-224

--- a/definitions_crypto_algorithms/definitions/algorithms/Digital Signature Algorithm/iso9796.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Digital Signature Algorithm/iso9796.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: ISO 9796 Digital Signature
-algorithmId: iso9796
-category: Digital Signature Algorithm
-strength: 1024-3072

--- a/definitions_crypto_algorithms/definitions/algorithms/Digital Signature Algorithm/rsassapss.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Digital Signature Algorithm/rsassapss.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: RSA Signature Scheme with Appendix - Probabilistic Signature Scheme
-algorithmId: rsassapss
-category: Digital Signature Algorithm
-strength: 1024-4096

--- a/definitions_crypto_algorithms/definitions/algorithms/Generic curves/gecc.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Generic curves/gecc.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Generic elliptic curve
-algorithmId: gecc
-category: Generic curves
-strength: '-'

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Function/harakav2.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Function/harakav2.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Haraka v2 Hash Function
-algorithmId: harakav2
-category: Hash Function
-strength: 256-512

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Function/kangarootwelve.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Function/kangarootwelve.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: KangarooTwelve Hash Function
-algorithmId: kangarootwelve
-category: Hash Function
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Function/kupyna.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Function/kupyna.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Kupyna Hash Function
-algorithmId: kupyna
-category: Hash Function
-strength: 256-512

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Function/marsupilamifourteen.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Function/marsupilamifourteen.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Marsupilami-14 Hash Function
-algorithmId: marsupilamifourteen
-category: Hash Function
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Function/parallelhash.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Function/parallelhash.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Parallel Hash Function
-algorithmId: parallelhash
-category: Hash Function
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Function/sm3.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Function/sm3.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: SM3 Cryptographic Hash Algorithm
-algorithmId: sm3
-category: Hash Function
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Function/tuplehash.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Function/tuplehash.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: TupleHash Function
-algorithmId: tuplehash
-category: Hash Function
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/blake2.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/blake2.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: BLAKE2
-algorithmId: blake2
-category: Hash Functions
-strength: 256/512

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/blake3.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/blake3.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: BLAKE3
-algorithmId: blake3
-category: Hash Functions
-strength: 256/512

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/haval.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/haval.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: HAVAL Hash Function
-algorithmId: haval
-category: Hash Functions
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/keccak.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/keccak.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Keecak
-algorithmId: keccak
-category: Hash Functions
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/md160.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/md160.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: RIPEMD-160 Hash Function
-algorithmId: md160
-category: Hash Functions
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/md2.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/md2.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: MD2 Message-Digest Algorithm
-algorithmId: md2
-category: Hash Functions
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/md4.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/md4.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: MD4 Message-Digest Algorithm
-algorithmId: md4
-category: Hash Functions
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/md5.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/md5.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: MD5 Message-Digest Algorithm
-algorithmId: md5
-category: Hash Functions
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/md6.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/md6.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: MD6 Message-Digest Algorithm
-algorithmId: md6
-category: Hash Functions
-strength: "512"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/mdc2.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/mdc2.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: MDC-2
-algorithmId: mdc2
-category: Hash Functions
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/ripemd.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/ripemd.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: RIPEMD Family of Hash Functions
-algorithmId: ripemd
-category: Hash Functions
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/sha1.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/sha1.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Secure Hash Algorithm 1
-algorithmId: sha1
-category: Hash Functions
-strength: "160"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/sha2.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/sha2.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Secure Hash Algorithm 2
-algorithmId: sha2
-category: Hash Functions
-strength: 224-512

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/sha3.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/sha3.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Secure Hash Algorithm 3
-algorithmId: sha3
-category: Hash Functions
-strength: 224-512

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/shs.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/shs.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Secure Hash Standard
-algorithmId: shs
-category: Hash Functions
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/skein.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/skein.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Skein Hash Function
-algorithmId: skein
-category: Hash Functions
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/ssha.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/ssha.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Salted SHA
-algorithmId: ssha
-category: Hash Functions
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/tiger.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/tiger.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Tiger Hash Function
-algorithmId: tiger
-category: Hash Functions
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/whirpool.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Hash Functions/whirpool.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Whirlpool Hash Function
-algorithmId: whirpool
-category: Hash Functions
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Agreement/ansix942.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Agreement/ansix942.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: ANSI X9.42 Key Agreement
-algorithmId: ansix942
-category: Key Agreement
-strength: 1024-3072

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Agreement/x25519.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Agreement/x25519.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: X25519 Key Exchange
-algorithmId: x25519
-category: Key Agreement
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Agreement/x448.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Agreement/x448.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: X448 Key Exchange
-algorithmId: x448
-category: Key Agreement
-strength: "224"

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Agreement/xdh.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Agreement/xdh.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Extended Diffie-Hellman
-algorithmId: xdh
-category: Key Agreement
-strength: 128-224

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/ansix963.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/ansix963.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: ANSI X9.63 Key Derivation Functions
-algorithmId: ansix963
-category: Key Derivation Functions
-strength: 128-512

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/bcrypt.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/bcrypt.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Bcrypt Password Hashing Function
-algorithmId: bcrypt
-category: Key Derivation Functions
-strength: "320"

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/concatenationkdf.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/concatenationkdf.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Concatenation Key Derivation Functions
-algorithmId: concatenationkdf
-category: Key Derivation Functions
-strength: 128-512

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/hkdf.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/hkdf.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: HMAC-based Key Derivation Functions
-algorithmId: hkdf
-category: Key Derivation Functions
-strength: 128-512

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/kdf1.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/kdf1.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Key Derivation Functions 1
-algorithmId: kdf1
-category: Key Derivation Functions
-strength: 128-512

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/kdf2.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/kdf2.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Key Derivation Functions 2
-algorithmId: kdf2
-category: Key Derivation Functions
-strength: 128-512

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/kdfcounter.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/kdfcounter.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Counter Mode Key Derivation Functions
-algorithmId: kdfcounter
-category: Key Derivation Functions
-strength: 128-512

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/kdfdoublepipeline.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/kdfdoublepipeline.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Double Pipeline Iteration Key Derivation Functions
-algorithmId: kdfdoublepipeline
-category: Key Derivation Functions
-strength: 128-512

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/kdffeedback.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/kdffeedback.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Feedback Mode Key Derivation Functions
-algorithmId: kdffeedback
-category: Key Derivation Functions
-strength: 128-512

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/kdfsession.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/kdfsession.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Session Key Derivation Functions
-algorithmId: kdfsession
-category: Key Derivation Functions
-strength: 128-512

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/mgf1.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/mgf1.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Mask Generation Function 1
-algorithmId: mgf1
-category: Key Derivation Functions
-strength: 128-512

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/pbe.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/pbe.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Password-Based Encryption
-algorithmId: pbe
-category: Key Derivation Functions
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/pbes1.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/pbes1.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Password-Based Encryption Scheme 1
-algorithmId: pbes1
-category: Key Derivation Functions
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/pbes2.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/pbes2.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Password-Based Encryption Scheme 2
-algorithmId: pbes2
-category: Key Derivation Functions
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/pbkdf1.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/pbkdf1.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Password-Based Key Derivation Function 1
-algorithmId: pbkdf1
-category: Key Derivation Functions
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/pbkdf2.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/pbkdf2.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Password-Based Key Derivation Function 2
-algorithmId: pbkdf2
-category: Key Derivation Functions
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/scrypt.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Derivation Functions/scrypt.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Scrypt Key Derivation Functions
-algorithmId: scrypt
-category: Key Derivation Functions
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Encapsulation/rsakem.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Encapsulation/rsakem.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: RSA Key Encapsulation Mechanism
-algorithmId: rsakem
-category: Key Encapsulation
-strength: 1024-4096

--- a/definitions_crypto_algorithms/definitions/algorithms/Key Wrapping/rfc3211wrap.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Key Wrapping/rfc3211wrap.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: RFC 3211 Password-based Key Wrapping
-algorithmId: rfc3211wrap
-category: Key Wrapping
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Message Authentication Codes/CMAC.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Message Authentication Codes/CMAC.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Cipher-based Message Authentication Codes
-algorithmId: CMAC
-category: Message Authentication Codes
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Message Authentication Codes/argon2.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Message Authentication Codes/argon2.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Cipher-based Message Authentication Codes
-algorithmId: argon2
-category: Message Authentication Codes
-strength: '-'

--- a/definitions_crypto_algorithms/definitions/algorithms/Message Authentication Codes/cms.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Message Authentication Codes/cms.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Count-Min Sketch
-algorithmId: cms
-category: Message Authentication Codes
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Message Authentication Codes/kmac.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Message Authentication Codes/kmac.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Keccak Message Authentication Codes
-algorithmId: kmac
-category: Message Authentication Codes
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Message Authentication Codes/siphash.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Message Authentication Codes/siphash.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: SipHash Pseudorandom Function
-algorithmId: siphash
-category: Message Authentication Codes
-strength: 64-128

--- a/definitions_crypto_algorithms/definitions/algorithms/Password Hashing/mscash.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Password Hashing/mscash.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Microsoft Cache Hash (MSCASH)
-algorithmId: mscash
-category: Password Hashing
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Password Hashing/mscash2.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Password Hashing/mscash2.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Microsoft Cache Hash v2 (MSCASH2)
-algorithmId: mscash2
-category: Password Hashing
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Polynomial Functions/adler32.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Polynomial Functions/adler32.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Adler-32 Checksum Algorithm
-algorithmId: adler32
-category: Polynomial Functions
-strength: "32"

--- a/definitions_crypto_algorithms/definitions/algorithms/Polynomial Functions/crc16.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Polynomial Functions/crc16.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Cyclic Redundancy Check 16-bit
-algorithmId: crc16
-category: Polynomial Functions
-strength: "16"

--- a/definitions_crypto_algorithms/definitions/algorithms/Polynomial Functions/crc32.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Polynomial Functions/crc32.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Cyclic Redundancy Check 32-bit
-algorithmId: crc32
-category: Polynomial Functions
-strength: "32"

--- a/definitions_crypto_algorithms/definitions/algorithms/Polynomial Functions/fasthash.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Polynomial Functions/fasthash.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: FastHash
-algorithmId: fasthash
-category: Polynomial Functions
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Polynomial Functions/fletcher.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Polynomial Functions/fletcher.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Fletcher
-algorithmId: fletcher
-category: Polynomial Functions
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Polynomial Functions/fnv1.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Polynomial Functions/fnv1.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Fowler–Noll–Vo
-algorithmId: fnv1
-category: Polynomial Functions
-strength: "1024"

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/bike.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/bike.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Bit Flipping Key Encapsulation
-algorithmId: bike
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/crystals-kyber.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/crystals-kyber.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Crystals-Kyber
-algorithmId: crystals-kyber
-category: Post-Quantum Cryptography
-strength: '-'

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/dilithium.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/dilithium.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: CRYSTALS-Dilithium Signature Algorithm
-algorithmId: dilithium
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/falcon.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/falcon.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Fast-Fourier Lattice-based Compact Signatures
-algorithmId: falcon
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/frodokem.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/frodokem.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: FrodoKEM Post-Quantum Key Encapsulation
-algorithmId: frodokem
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/gemss.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/gemss.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Great Multivariate Signature Scheme
-algorithmId: gemss
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/gmss.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/gmss.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Generalized Merkle Signature Scheme
-algorithmId: gmss
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/hqc.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/hqc.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Hamming Quasi-Cyclic
-algorithmId: hqc
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/hss.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/hss.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Hierarchical Signature Scheme
-algorithmId: hss
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/lms.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/lms.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Leighton-Micali Signature Scheme
-algorithmId: lms
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/mceliece.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/mceliece.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: McEliece
-algorithmId: mceliece
-category: Post-Quantum Cryptography
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/mldsa.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/mldsa.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Multilevel Digital Signature Algorithm
-algorithmId: mldsa
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/mlkem.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/mlkem.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Module Lattice Key Encapsulation Mechanism
-algorithmId: mlkem
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/ntruencrypt.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/ntruencrypt.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: NTRUEncrypt
-algorithmId: ntruencrypt
-category: Post-Quantum Cryptography
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/picnic.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/picnic.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Picnic Signature Algorithm
-algorithmId: picnic
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/qtesla.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/qtesla.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Quantum-resistant Tesla Signature Scheme
-algorithmId: qtesla
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/rainbow.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/rainbow.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Rainbow
-algorithmId: rainbow
-category: Post-Quantum Cryptography
-strength: '-'

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/sike.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/sike.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Supersingular Isogeny Key Encapsulation
-algorithmId: sike
-category: Post-Quantum Cryptography
-strength: '-'

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/sphincs+.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/sphincs+.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: SPHINCS+
-algorithmId: sphincs+
-category: Post-Quantum Cryptography
-strength: '-'

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/sphincsplus.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/sphincsplus.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: SPHINCS+ Signature Algorithm
-algorithmId: sphincsplus
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/xmss.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/xmss.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: eXtended Merkle Signature Scheme
-algorithmId: xmss
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/xmssmt.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Post-Quantum Cryptography/xmssmt.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: XMSS Multi-Tree Signature Scheme
-algorithmId: xmssmt
-category: Post-Quantum Cryptography
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Random Number Generation/ansix931.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Random Number Generation/ansix931.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: ANSI X9.31 Random Number Generator
-algorithmId: ansix931
-category: Random Number Generation
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Random Number Generation/csprng.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Random Number Generation/csprng.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Cryptographically Secure Pseudo-Random Number Generator
-algorithmId: csprng
-category: Random Number Generation
-strength: '-'

--- a/definitions_crypto_algorithms/definitions/algorithms/Random Number Generation/drbg.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Random Number Generation/drbg.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Deterministic Random Bit Generator
-algorithmId: drbg
-category: Random Number Generation
-strength: '-'

--- a/definitions_crypto_algorithms/definitions/algorithms/Random Number Generation/fortuna.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Random Number Generation/fortuna.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Fortuna
-algorithmId: fortuna
-category: Random Number Generation
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Random Number Generation/isaac.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Random Number Generation/isaac.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: ISAAC Stream Cipher
-algorithmId: isaac
-category: Random Number Generation
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Random Number Generation/yarrow.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Random Number Generation/yarrow.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Yarrow Pseudorandom Number Generator
-algorithmId: yarrow
-category: Random Number Generation
-strength: "160"

--- a/definitions_crypto_algorithms/definitions/algorithms/Secure Protocols/fcrypt.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Secure Protocols/fcrypt.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: ""
-algorithmId: fcrypt
-category: Secure Protocols
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Secure Protocols/feal.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Secure Protocols/feal.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Fast Data Encipherment Algorithm
-algorithmId: feal
-category: Secure Protocols
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Secure Protocols/gea0-x.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Secure Protocols/gea0-x.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: GSM Encryption Algorithm
-algorithmId: gea0-x
-category: Secure Protocols
-strength: 64-128

--- a/definitions_crypto_algorithms/definitions/algorithms/Secure Protocols/nimbus.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Secure Protocols/nimbus.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Nimbus
-algorithmId: nimbus
-category: Secure Protocols
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Secure Protocols/seal.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Secure Protocols/seal.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Software-optimized Encryption Algorithm
-algorithmId: seal
-category: Secure Protocols
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Secure Protocols/srp.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Secure Protocols/srp.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Secure Remote Password
-algorithmId: srp
-category: Secure Protocols
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Secure Protocols/tcrypt.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Secure Protocols/tcrypt.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: TCrypt Disk Encryption
-algorithmId: tcrypt
-category: Secure Protocols
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Stream Cipher/hc.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Stream Cipher/hc.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: HC Stream Cipher
-algorithmId: hc
-category: Stream Cipher
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/3des.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/3des.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Triple Data Encryption Standard
-algorithmId: 3des
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/3way.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/3way.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: 3 Way
-algorithmId: 3way
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/aes.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/aes.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Advanced Encryption Standard
-algorithmId: aes
-category: Symmetric Encryption
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/aria.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/aria.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: ARIA Block Cipher
-algorithmId: aria
-category: Symmetric Encryption
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/bearlion.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/bearlion.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: BearLion
-algorithmId: bearlion
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/blowfish.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/blowfish.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Blowfish Block Cipher
-algorithmId: blowfish
-category: Symmetric Encryption
-strength: "320"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/camellia.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/camellia.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Camellia
-algorithmId: camellia
-category: Symmetric Encryption
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/cast.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/cast.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: CAST Block Cipher Family
-algorithmId: cast
-category: Symmetric Encryption
-strength: "320"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/chacha20.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/chacha20.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: ChaCha
-algorithmId: chacha20
-category: Symmetric Encryption
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/cmea.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/cmea.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Cellular Message Encryption Algorithm
-algorithmId: cmea
-category: Symmetric Encryption
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/cobra.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/cobra.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Cobra Stream Cipher
-algorithmId: cobra
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/des.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/des.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Data Encryption Standard
-algorithmId: des
-category: Symmetric Encryption
-strength: "168"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/desede.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/desede.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Triple Data Encryption Standard (DESede)
-algorithmId: desede
-category: Symmetric Encryption
-strength: "168"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/f8.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/f8.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: F8 Mode of Operation
-algorithmId: f8
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/gost.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/gost.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: GOST Block Cipher
-algorithmId: gost
-category: Symmetric Encryption
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/grain.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/grain.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Grain
-algorithmId: grain
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/hc128.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/hc128.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: HC-128
-algorithmId: hc128
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/hc256.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/hc256.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: HC-256
-algorithmId: hc256
-category: Symmetric Encryption
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/hmac.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/hmac.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Hash-based Message Authentication Codes
-algorithmId: hmac
-category: Symmetric Encryption
-strength: '-'

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/ice.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/ice.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Indispensable Cryptographic Engine
-algorithmId: ice
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/idea.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/idea.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: International Data Encryption Algorithm
-algorithmId: idea
-category: Symmetric Encryption
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/juniper.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/juniper.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Juniper
-algorithmId: juniper
-category: Symmetric Encryption
-strength: ""

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/kalyna.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/kalyna.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Kalyna Block Cipher
-algorithmId: kalyna
-category: Symmetric Encryption
-strength: 128-512

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/kazumi.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/kazumi.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Kasumi
-algorithmId: kazumi
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/khazad.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/khazad.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Khazad
-algorithmId: khazad
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/lea.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/lea.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Lightweight Encryption Algorithm
-algorithmId: lea
-category: Symmetric Encryption
-strength: 128-256

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/loki91.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/loki91.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: LOKI-91 Block Cipher
-algorithmId: loki91
-category: Symmetric Encryption
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/lucifer.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/lucifer.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Lucifer Block Cipher
-algorithmId: lucifer
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/misty1.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/misty1.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: MISTY1 Block Cipher
-algorithmId: misty1
-category: Symmetric Encryption
-strength: "32"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/multi2.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/multi2.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Multi2
-algorithmId: multi2
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/noekeon.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/noekeon.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Noekeon Block Cipher
-algorithmId: noekeon
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/panama.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/panama.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: PANAMA
-algorithmId: panama
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/quad.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/quad.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Quad
-algorithmId: quad
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/rabbit.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/rabbit.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Rabbit
-algorithmId: rabbit
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/rc2.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/rc2.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: RC2 Block Cipher
-algorithmId: rc2
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/rc4-hmac.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/rc4-hmac.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: RC4 with HMAC
-algorithmId: rc4-hmac
-category: Symmetric Encryption
-strength: "2048"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/rc4.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/rc4.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: RC4 Stream Cipher
-algorithmId: rc4
-category: Symmetric Encryption
-strength: "2048"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/rc5.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/rc5.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: RC5 Block Cipher
-algorithmId: rc5
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/rc6.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/rc6.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: RC6 Block Cipher
-algorithmId: rc6
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/rijndael.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/rijndael.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Rijndael
-algorithmId: rijndael
-category: Symmetric Encryption
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/safer.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/safer.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Secure And Fast Encryption Routine
-algorithmId: safer
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/salsa10.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/salsa10.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Salsa10 Stream Cipher
-algorithmId: salsa10
-category: Symmetric Encryption
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/salsa20.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/salsa20.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Salsa20 Stream Cipher
-algorithmId: salsa20
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/sapphire.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/sapphire.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Sapphire Stream Cipher
-algorithmId: sapphire
-category: Symmetric Encryption
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/seed.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/seed.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: SEED Block Cipher
-algorithmId: seed
-category: Symmetric Encryption
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/serpent.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/serpent.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Serpent Block Cipher
-algorithmId: serpent
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/shacal.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/shacal.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: SHACAL Block Cipher
-algorithmId: shacal
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/shark.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/shark.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: SHARK Block Cipher
-algorithmId: shark
-category: Symmetric Encryption
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/skipjack.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/skipjack.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: SKIPJACK Block Cipher
-algorithmId: skipjack
-category: Symmetric Encryption
-strength: "32"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/sms4.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/sms4.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: SMS4 Block Cipher
-algorithmId: sms4
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/snerfu.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/snerfu.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: SNERFU Hash Function
-algorithmId: snerfu
-category: Symmetric Encryption
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/snow.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/snow.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: SNOW Stream Cipher
-algorithmId: snow
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/sober.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/sober.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: SOBER Stream Cipher
-algorithmId: sober
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/sosemanuk.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/sosemanuk.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Sosemanuk Stream Cipher
-algorithmId: sosemanuk
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/tdes.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/tdes.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Triple Data Encryption Standard
-algorithmId: tdes
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/tea.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/tea.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Tiny Encryption Algorithm
-algorithmId: tea
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/threefish.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/threefish.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Threefish Block Cipher
-algorithmId: threefish
-category: Symmetric Encryption
-strength: "1024"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/tnepres.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/tnepres.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Serpent Block Cipher (reversed)
-algorithmId: tnepres
-category: Symmetric Encryption
-strength: "256"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/twofish.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/twofish.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Twofish Block Cipher
-algorithmId: twofish
-category: Symmetric Encryption
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/vmpc.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/vmpc.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Variably Modified Permutation Composition
-algorithmId: vmpc
-category: Symmetric Encryption
-strength: ""

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/wake.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/wake.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Word Auto Key Encryption
-algorithmId: wake
-category: Symmetric Encryption
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/xtea.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/xtea.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: eXtended Tiny Encryption Algorithm
-algorithmId: xtea
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/zipcrypt.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/zipcrypt.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: ZipCrypto
-algorithmId: zipcrypt
-category: Symmetric Encryption
-strength: "64"

--- a/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/zuc.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Symmetric Encryption/zuc.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: ZUC Stream Cipher
-algorithmId: zuc
-category: Symmetric Encryption
-strength: "128"

--- a/definitions_crypto_algorithms/definitions/algorithms/Zero-Knowledge Proof/zk-snarks.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Zero-Knowledge Proof/zk-snarks.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Zero-Knowledge Succinct Non-Interactive Arguments of Knowledge
-algorithmId: zk-snarks
-category: Zero-Knowledge Proof
-strength: '-'

--- a/definitions_crypto_algorithms/definitions/algorithms/Zero-Knowledge Proof/zk-starks.yaml
+++ b/definitions_crypto_algorithms/definitions/algorithms/Zero-Knowledge Proof/zk-starks.yaml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: CC0-1.0
-algorithm: Zero-Knowledge Scalable Transparent Arguments of Knowledge
-algorithmId: zk-starks
-category: Zero-Knowledge Proof
-strength: '-'


### PR DESCRIPTION
Remove duplicated algorithms folder

`algorithms` folder is duplicated, the one being used is `definitions_crypto_algorithms/algorithms`


```
diff -r definitions_crypto_algorithms/algorithms definitions_crypto_algorithms/definitions/algorithms
```
