### PR TITLE
Fix more whirlpool typos (#47)

### DIFF
--- a/definitions_crypto_algorithms/README.md
+++ b/definitions_crypto_algorithms/README.md
@@ -140,7 +140,7 @@ Keywords definition for each algorithm can be found on:
 | skein | Skein Hash Function | 256 |
 | ssha | Salted SHA | 128 |
 | tiger | Tiger Hash Function | 256 |
-| whirpool | Whirlpool Hash Function | 128 |
+| whirlpool | Whirlpool Hash Function | 128 |
 
 ## Key Agreement
 

--- a/definitions_crypto_algorithms/algorithms/Hash Functions/whirlpool.yaml
+++ b/definitions_crypto_algorithms/algorithms/Hash Functions/whirlpool.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: CC0-1.0
 algorithm: Whirlpool Hash Function
-algorithmId: whirpool
+algorithmId: whirlpool
 category: Hash Functions
 strength: "128"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the spelling of the Whirlpool hash algorithm ID from "whirpool" to "whirlpool" in documentation and algorithm definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->